### PR TITLE
feat Empty State and integration

### DIFF
--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,18 @@
+import { Heading } from './heading';
+import { Inbox } from 'lucide-react';
+import { Paragraph } from './paragraph';
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+}
+
+export const EmptyState = ({ description, title }: EmptyStateProps) => {
+  return (
+    <div className="flex flex-col w-full lg:mt-20 mt-0 gap-8 justify-center items-center">
+      <Heading className="!text-center">Sem {title} até o momento.</Heading>
+      <Inbox className="w-16 h-16 text-center" />
+      <Paragraph className="font-semibold text-center">{description}</Paragraph>
+    </div>
+  );
+};

--- a/src/pageTemplates/clients-template/indications-template/index.tsx
+++ b/src/pageTemplates/clients-template/indications-template/index.tsx
@@ -1,9 +1,11 @@
 'use client';
+
 import { fetchIndications } from '@/api/indications/fetch-indications';
 import { PrivateLayout } from '@/components/layouts/private-layout.tsx';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Spinner } from '@/components/ui/spinner';
+import { EmptyState } from '@/components/ui/empty-state';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { formatDateAndHour } from '@/utils/format-date-and-hour';
 import { useQuery } from '@tanstack/react-query';
@@ -26,13 +28,13 @@ export const ClientIndicationsTemplate = () => {
         <div className="flex items-center justify-center">
           <Spinner />
         </div>
-      ) : (
+      ) : indications.length > 0 ? (
         <div className="flex flex-col gap-4">
           {indications.map((indication) => {
             return (
               <section
                 key={indication.id}
-                className="border border-border rounded-lg p-8 flex flex-col gap-8 "
+                className="border border-border rounded-lg p-8 flex flex-col gap-8"
               >
                 <div className="flex items-center gap-8">
                   <div className="bg-green-100 p-4 rounded-lg flex items-center justify-center">
@@ -53,6 +55,11 @@ export const ClientIndicationsTemplate = () => {
             );
           })}
         </div>
+      ) : (
+        <EmptyState
+          title="indicações"
+          description="Compartilhe a diversão da KongGames e ganhe pontos por cada amigo indicado!"
+        />
       )}
     </PrivateLayout>
   );

--- a/src/pageTemplates/clients-template/statement-template/index.tsx
+++ b/src/pageTemplates/clients-template/statement-template/index.tsx
@@ -1,9 +1,11 @@
 'use client';
+
 import { fetchStatement } from '@/api/statement/fetch-statement';
 import { PrivateLayout } from '@/components/layouts/private-layout.tsx';
 import { Heading } from '@/components/ui/heading';
 import { Paragraph } from '@/components/ui/paragraph';
 import { Spinner } from '@/components/ui/spinner';
+import { EmptyState } from '@/components/ui/empty-state';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { formatDateAndHour } from '@/utils/format-date-and-hour';
 import { useQuery } from '@tanstack/react-query';
@@ -27,7 +29,7 @@ export const ClientStatementTemplate = () => {
         <div className="flex items-center justify-center">
           <Spinner />
         </div>
-      ) : (
+      ) : statement.length > 0 ? (
         <div className="flex flex-col gap-4">
           {statement.map((s) => {
             const added = !s.type;
@@ -36,7 +38,7 @@ export const ClientStatementTemplate = () => {
             return (
               <section
                 key={s.id}
-                className="border border-border rounded-lg p-8 flex flex-col gap-8  "
+                className="border border-border rounded-lg p-8 flex flex-col gap-8"
               >
                 <div className="flex items-center gap-8">
                   <div
@@ -78,6 +80,11 @@ export const ClientStatementTemplate = () => {
             );
           })}
         </div>
+      ) : (
+        <EmptyState
+          title="extrato de pontos"
+          description="Ganhe mais jogando: troque seus pontos por experiências únicas!"
+        />
       )}
     </PrivateLayout>
   );


### PR DESCRIPTION
### Link para ClickUp
https://www.notion.so/f5b2224238fb48929b4fea6d45da7f05?v=61e4c02748024e34b2c4a730c413162e&p=18144dd55bc2808789d1d9c8fdfbb5f9&pm=s

### Objetivo
Este PR consiste em adicionar um empty state para as telas de indicações e extratos.

###Descrição
1-	"Criei o componente junto com os demais, para que possamos reaproveitá-lo o máximo possível. O componente consiste em um título, o ícone Inbox do Lucide React vazio e uma descrição. Um componente simples, mas muito útil."

2-	"Integração do componente EmptyState dentro do ClientStatementTemplate."

3 -  "Integração do componente EmptyState dentro do ClientIndicationsTemplate."

![image](https://github.com/user-attachments/assets/4d76b13a-76a0-49be-a5e9-4293880bb61e)

![image](https://github.com/user-attachments/assets/8c386067-822d-4d3e-9d55-d12ba9c0b748)
